### PR TITLE
Wire indexing in ops tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyquil>=2.16
-pennylane>=0.11
+git+https://github.com/PennyLaneAI/pennylane.git
 networkx
 flaky

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -25,9 +25,9 @@ class TestDecompositions:
             gate_matrix = gate.matrix
 
             if gate.num_wires == 1:
-                if gate.wires[0] == Wires(0):
+                if gate.wires[0] == 0:
                     gate_matrix = np.kron(gate_matrix, np.eye(2, dtype=complex))
-                elif gate.wires[0] == Wires(1):
+                elif gate.wires[0] == 1:
                     gate_matrix = np.kron(np.eye(2, dtype=complex), gate_matrix)
 
             calculated_matrix = gate_matrix @ calculated_matrix
@@ -48,9 +48,9 @@ class TestDecompositions:
             gate_matrix = gate.matrix
 
             if gate.num_wires == 1:
-                if gate.wires[0] == Wires(0):
+                if gate.wires[0] == 0:
                     gate_matrix = np.kron(gate_matrix, np.eye(2, dtype=complex))
-                elif gate.wires[0] == Wires(1):
+                elif gate.wires[0] == 1:
                     gate_matrix = np.kron(np.eye(2, dtype=complex), gate_matrix)
 
             calculated_matrix = gate_matrix @ calculated_matrix
@@ -70,9 +70,9 @@ class TestDecompositions:
             gate_matrix = gate.matrix
 
             if gate.num_wires == 1:
-                if gate.wires[0] == Wires(0):
+                if gate.wires[0] == 0:
                     gate_matrix = np.kron(gate_matrix, np.eye(2, dtype=complex))
-                elif gate.wires[0] == Wires(1):
+                elif gate.wires[0] == 1:
                     gate_matrix = np.kron(np.eye(2, dtype=complex), gate_matrix)
 
             calculated_matrix = gate_matrix @ calculated_matrix


### PR DESCRIPTION
Updates tests using `Wires` objects after some updates in PennyLane core (e.g., https://github.com/PennyLaneAI/pennylane/commit/c1bfc27d6e191f034ff79ad01cfad2416198ecdc).

Indexing a `Wires` object now returns a single wire label instead of a `Wires` object with a single wire label:
```python
In [5]: qml.wires.Wires([0,1])[0]
Out[5]: 0
```