### PR TITLE
Incrementing the version number to 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,28 @@
-# Release 0.13.0-dev
+# Release 0.14.0
 
 ### New features since last release
 
 ### Improvements
 
+* Updated the CI.
+  [(#63)](https://github.com/PennyLaneAI/pennylane-forest/pull/63)
+
 ### Bug fixes
 
+* Updated the plugin to be compatible with the new core of PennyLane.
+  [(#67)](https://github.com/PennyLaneAI/pennylane-forest/pull/67)
+  [(#68)](https://github.com/PennyLaneAI/pennylane-forest/pull/68)
+
 ### Documentation
+
+* Adapted the documentation to the PennyLane theme.
+  [(#64)](https://github.com/PennyLaneAI/pennylane-forest/pull/64)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Thomas Bromley, Theodor Isacsson, Josh Izaac, Maria Schuld, Antal Száva.
 
 ---
 

--- a/pennylane_forest/_version.py
+++ b/pennylane_forest/_version.py
@@ -2,4 +2,4 @@
    Version number (convention major.minor.patch[-label])
 """
 
-__version__ = "0.13.0-dev"
+__version__ = "0.14.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyquil>=2.16
-git+https://github.com/PennyLaneAI/pennylane.git
+pennylane>=0.11
 networkx
 flaky


### PR DESCRIPTION
* The PennyLane version requirement was set back to `pennylane>=0.11` because
    * The converter feature and the `QPUDevice` was disabled based on the PennyLane version (`pennylane>=0.14`)
    * Only the tests of the plugin had to be updated
* Updated the changelog
* Incremented the version number