### PR TITLE
Pre v0 15 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,26 @@
-# Release 0.15.0-dev
-
-### New features since last release
+# Release 0.15.0
 
 ### Breaking changes
 
-### Improvements
+* For compatibility with PennyLane v0.15, the `analytic` keyword argument
+  has been removed from all devices. Analytic expectation values can
+  still be computed by setting `shots=None`.
+  [(#71)](https://github.com/PennyLaneAI/pennylane-forest/pull/71)
 
-### Documentation
+* For compatibility with PennyLane v0.15, parametric compilation now depends on
+  the `requires_grad` attribute of parameters instead of the deprecated
+  `Variable` class.
+  [(#71)](https://github.com/PennyLaneAI/pennylane-forest/pull/71)
 
-### Bug fixes
+* The circuit hashes used for parametric compilation are computed in
+  `QVMDevice` instead of in `QubitDevice` defined in Pennylane.
+  [(#71)](https://github.com/PennyLaneAI/pennylane-forest/pull/71)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Antal Száva.
 
 ---
 

--- a/pennylane_forest/_version.py
+++ b/pennylane_forest/_version.py
@@ -2,4 +2,4 @@
    Version number (convention major.minor.patch[-label])
 """
 
-__version__ = "0.15.0-dev"
+__version__ = "0.15.0"

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -173,7 +173,7 @@ class ForestDevice(QubitDevice):
             to estimate expectation values of observables.
             For simulator devices, 0 means the exact EV is returned.
     """
-    pennylane_requires = ">=0.11"
+    pennylane_requires = ">=0.15"
     version = __version__
     author = "Rigetti Computing Inc."
 

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -180,9 +180,8 @@ class ForestDevice(QubitDevice):
     _operation_map = pyquil_operation_map
     _capabilities = {"model": "qubit", "tensor_observables": True}
 
-    def __init__(self, wires, shots=1000, analytic=False, **kwargs):
-        super().__init__(wires, shots, analytic=analytic)
-        self.analytic = analytic
+    def __init__(self, wires, shots=1000, **kwargs):
+        super().__init__(wires, shots)
         self.reset()
 
     @staticmethod

--- a/pennylane_forest/numpy_wavefunction.py
+++ b/pennylane_forest/numpy_wavefunction.py
@@ -45,7 +45,7 @@ class NumpyWavefunctionDevice(ForestDevice):
 
     observables = {"PauliX", "PauliY", "PauliZ", "Hadamard", "Hermitian", "Identity"}
 
-    def __init__(self, wires, *, shots=1000, **kwargs):
+    def __init__(self, wires, *, shots=None, **kwargs):
         super().__init__(wires, shots, **kwargs)
         self.qc = PyQVM(n_qubits=len(self.wires), quantum_simulator_type=NumpyWavefunctionSimulator)
         self._state = None

--- a/pennylane_forest/numpy_wavefunction.py
+++ b/pennylane_forest/numpy_wavefunction.py
@@ -45,8 +45,8 @@ class NumpyWavefunctionDevice(ForestDevice):
 
     observables = {"PauliX", "PauliY", "PauliZ", "Hadamard", "Hermitian", "Identity"}
 
-    def __init__(self, wires, *, shots=1000, analytic=True, **kwargs):
-        super().__init__(wires, shots, analytic, **kwargs)
+    def __init__(self, wires, *, shots=1000, **kwargs):
+        super().__init__(wires, shots, **kwargs)
         self.qc = PyQVM(n_qubits=len(self.wires), quantum_simulator_type=NumpyWavefunctionSimulator)
         self._state = None
 

--- a/pennylane_forest/qvm.py
+++ b/pennylane_forest/qvm.py
@@ -192,7 +192,7 @@ class QVMDevice(ForestDevice):
             # Prepare for parametric compilation
             par = []
             for param in operation.data:
-                if getattr(param, "requires_grad", True):
+                if getattr(param, "requires_grad", False):
                     # Using the idx for trainable parameter objects to specify the
                     # corresponding symbolic parameter
                     parameter_string = "theta" + str(id(param))
@@ -204,7 +204,7 @@ class QVMDevice(ForestDevice):
                         self._parameter_reference_map[parameter_string] = current_ref
 
                     # Store the numeric value bound to the symbolic parameter
-                    self._parameter_map[parameter_string] = [param.val]
+                    self._parameter_map[parameter_string] = [param.unwrap()]
 
                     # Appending the parameter reference to the parameters
                     # of the corresponding operation

--- a/pennylane_forest/qvm.py
+++ b/pennylane_forest/qvm.py
@@ -28,7 +28,6 @@ from pyquil.gates import MEASURE, RESET
 from pyquil.quil import Pragma, Program
 
 from pennylane import DeviceError
-from pennylane.variable import Variable
 
 from ._version import __version__
 from .device import ForestDevice
@@ -192,10 +191,10 @@ class QVMDevice(ForestDevice):
             # Prepare for parametric compilation
             par = []
             for param in operation.data:
-                if isinstance(param, Variable):
-                    # Using the idx for each Variable instance to specify the
+                if getattr(param, "requires_grad", True):
+                    # Using the idx for trainable parameter objects to specify the
                     # corresponding symbolic parameter
-                    parameter_string = "theta" + str(param.idx)
+                    parameter_string = "theta" + id(param)
 
                     if parameter_string not in self._parameter_reference_map:
                         # Create a new PyQuil memory reference and store it in the

--- a/pennylane_forest/qvm.py
+++ b/pennylane_forest/qvm.py
@@ -195,7 +195,7 @@ class QVMDevice(ForestDevice):
                 if getattr(param, "requires_grad", True):
                     # Using the idx for trainable parameter objects to specify the
                     # corresponding symbolic parameter
-                    parameter_string = "theta" + id(param)
+                    parameter_string = "theta" + str(id(param))
 
                     if parameter_string not in self._parameter_reference_map:
                         # Create a new PyQuil memory reference and store it in the

--- a/pennylane_forest/qvm.py
+++ b/pennylane_forest/qvm.py
@@ -203,7 +203,7 @@ class QVMDevice(ForestDevice):
             # Prepare for parametric compilation
             par = []
             for param in operation.data:
-                if getattr(param, "requires_grad", False):
+                if getattr(param, "requires_grad", False) and operation.name is not "BasisState":
                     # Using the idx for trainable parameter objects to specify the
                     # corresponding symbolic parameter
                     parameter_string = "theta" + str(id(param))

--- a/pennylane_forest/wavefunction.py
+++ b/pennylane_forest/wavefunction.py
@@ -74,8 +74,8 @@ class WavefunctionDevice(ForestDevice):
 
     observables = {"PauliX", "PauliY", "PauliZ", "Hadamard", "Hermitian", "Identity"}
 
-    def __init__(self, wires, *, shots=1000, analytic=True, **kwargs):
-        super().__init__(wires, shots, analytic, **kwargs)
+    def __init__(self, wires, *, shots=None, **kwargs):
+        super().__init__(wires, shots, **kwargs)
         self.connection = super()._get_connection(**kwargs)
         self.qc = WavefunctionSimulator(connection=self.connection)
         self._state = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyquil>=2.16
-pennylane>=0.11
+git+https://github.com/PennyLaneAI/pennylane.git
 networkx
 flaky

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("pennylane_forest/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
 
 
-requirements = ["pyquil>=2.16", "pennylane>=0.11"]
+requirements = ["pyquil>=2.16", "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git"]
 
 info = {
     "name": "PennyLane-Forest",

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1231,9 +1231,8 @@ class TestIntegration:
     PHI = np.linspace(0.32, 3, 5)
     VARPHI = np.linspace(0.02, 3, 5)
 
-    @pytest.mark.parametrize("analytic", [True])
     @pytest.mark.parametrize("theta,phi,varphi", list(zip(THETA, PHI, VARPHI)))
-    def test_gradient(self, theta, phi, varphi, analytic, tol):
+    def test_gradient(self, theta, phi, varphi, tol):
         """Test that the gradient works correctly"""
         program = pyquil.Program()
 
@@ -1250,7 +1249,7 @@ class TestIntegration:
         # Convert to a PennyLane circuit
         program_pl = qml.load(program, format="pyquil_program")
 
-        dev = qml.device("default.qubit", wires=3, analytic=analytic)
+        dev = qml.device("default.qubit", wires=3)
 
         @qml.qnode(dev)
         def circuit(params):

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -6,7 +6,7 @@ import pennylane as qml
 import pyquil
 import pyquil.gates as g
 import pytest
-from pennylane._queuing import OperationRecorder
+from pennylane.tape import OperationRecorder
 from pennylane_forest.converter import *
 
 

--- a/tests/test_qvm.py
+++ b/tests/test_qvm.py
@@ -487,10 +487,10 @@ class TestQVMBasic(BaseTest):
         with pytest.raises(ValueError, match="Number of shots must be a positive integer."):
             dev = plf.QVMDevice(device="2q-qvm", shots=shots)
 
-    def test_raise_error_if_analytic_true(self, shots):
-        """Test that instantiating a QVMDevice in analytic=True mode raises an error"""
-        with pytest.raises(ValueError, match="QVM device cannot be run in analytic=True mode."):
-            dev = plf.QVMDevice(device="2q-qvm", shots=shots, analytic=True)
+    def test_raise_error_if_shots_is_none(self, shots):
+        """Test that instantiating a QVMDevice to be used for analytic computations raises an error"""
+        with pytest.raises(ValueError, match="QVM device cannot be used for analytic computations."):
+            dev = plf.QVMDevice(device="2q-qvm", shots=None)
 
     @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(TEST_QPU_LATTICES)])
     def test_timeout_set_correctly(self, shots, device):

--- a/tests/test_qvm.py
+++ b/tests/test_qvm.py
@@ -747,7 +747,7 @@ class TestQVMIntegration(BaseTest):
         @qml.qnode(dev)
         def circuit(x, y, z):
             """Reference QNode"""
-            qml.BasisState(np.array([1]), wires=0)
+            qml.BasisState(np.array([1], requires_grad=False), wires=0)
             qml.Hadamard(wires=0)
             qml.Rot(x, y, z, wires=0)
             return qml.expval(qml.PauliZ(0))

--- a/tests/test_qvm.py
+++ b/tests/test_qvm.py
@@ -732,7 +732,8 @@ class TestQVMIntegration(BaseTest):
 
     @flaky(max_runs=10, min_passes=2)
     @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(TEST_QPU_LATTICES)])
-    def test_one_qubit_wavefunction_circuit(self, device, qvm, compiler):
+    @pytest.mark.parametrize("requires_grad", [True, False])
+    def test_one_qubit_wavefunction_circuit(self, device, qvm, compiler, requires_grad):
         """Test that the wavefunction plugin provides correct result for simple circuit.
 
         As the results coming from the qvm are stochastic, a constraint of 2 out of 5 runs was added.
@@ -747,7 +748,7 @@ class TestQVMIntegration(BaseTest):
         @qml.qnode(dev)
         def circuit(x, y, z):
             """Reference QNode"""
-            qml.BasisState(np.array([1], requires_grad=False), wires=0)
+            qml.BasisState(np.array([1], requires_grad=requires_grad), wires=0)
             qml.Hadamard(wires=0)
             qml.Rot(x, y, z, wires=0)
             return qml.expval(qml.PauliZ(0))

--- a/tests/test_qvm.py
+++ b/tests/test_qvm.py
@@ -54,14 +54,14 @@ class TestQVMBasic(BaseTest):
 
         dev = plf.QVMDevice(device="2q-qvm", shots=shots)
 
-        O1 = qml.expval(qml.Identity(wires=[0]))
-        O2 = qml.expval(qml.Identity(wires=[1]))
+        with qml.tape.QuantumTape() as tape:
+            qml.RX(theta, wires=[0])
+            qml.RX(phi, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            O1 = qml.expval(qml.Identity(wires=[0]))
+            O2 = qml.expval(qml.Identity(wires=[1]))
 
-        circuit_graph = CircuitGraph(
-            [qml.RX(theta, wires=[0]), qml.RX(phi, wires=[1]), qml.CNOT(wires=[0, 1])], [O1, O2], dev.wires
-        )
-
-        dev.apply(circuit_graph.operations, rotations=circuit_graph.diagonalizing_gates)
+        dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
         dev._samples = dev.generate_samples()
 
@@ -77,17 +77,14 @@ class TestQVMBasic(BaseTest):
 
         dev = plf.QVMDevice(device="2q-qvm", shots=shots)
 
-        O1 = qml.expval(qml.PauliZ(wires=[0]))
-        O2 = qml.expval(qml.PauliZ(wires=[1]))
+        with qml.tape.QuantumTape() as tape:
+            qml.RX(theta, wires=[0])
+            qml.RX(phi, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            O1 = qml.expval(qml.PauliZ(wires=[0]))
+            O2 = qml.expval(qml.PauliZ(wires=[1]))
 
-        circuit_graph = CircuitGraph(
-            [qml.RX(theta, wires=[0]), qml.RX(phi, wires=[1]), qml.CNOT(wires=[0, 1])] + [O1, O2],
-            {},
-            dev.wires,
-        )
-
-        dev.apply(circuit_graph.operations, rotations=circuit_graph.diagonalizing_gates)
-
+        dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
 
         res = np.array([dev.expval(O1), dev.expval(O2)])
@@ -103,17 +100,15 @@ class TestQVMBasic(BaseTest):
         phi = 0.123
 
         dev = plf.QVMDevice(device="2q-qvm", shots=shots)
-        O1 = qml.expval(qml.PauliX(wires=[0]))
-        O2 = qml.expval(qml.PauliX(wires=[1]))
 
-        circuit_graph = CircuitGraph(
-            [qml.RY(theta, wires=[0]), qml.RY(phi, wires=[1]), qml.CNOT(wires=[0, 1])] + [O1, O2],
-            {},
-            dev.wires,
-        )
+        with qml.tape.QuantumTape() as tape:
+            qml.RY(theta, wires=[0])
+            qml.RY(phi, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            O1 = qml.expval(qml.PauliX(wires=[0]))
+            O2 = qml.expval(qml.PauliX(wires=[1]))
 
-        dev.apply(circuit_graph.operations, rotations=circuit_graph.diagonalizing_gates)
-
+        dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
 
         res = np.array([dev.expval(O1), dev.expval(O2)])
@@ -128,17 +123,15 @@ class TestQVMBasic(BaseTest):
         phi = 0.123
 
         dev = plf.QVMDevice(device="2q-qvm", shots=shots)
-        O1 = qml.expval(qml.PauliY(wires=[0]))
-        O2 = qml.expval(qml.PauliY(wires=[1]))
 
-        circuit_graph = CircuitGraph(
-            [qml.RX(theta, wires=[0]), qml.RX(phi, wires=[1]), qml.CNOT(wires=[0, 1])] + [O1, O2],
-            {},
-            dev.wires,
-        )
+        with qml.tape.QuantumTape() as tape:
+            qml.RX(theta, wires=[0])
+            qml.RX(phi, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            O1 = qml.expval(qml.PauliY(wires=[0]))
+            O2 = qml.expval(qml.PauliY(wires=[1]))
 
-        dev.apply(circuit_graph.operations, rotations=circuit_graph.diagonalizing_gates)
-
+        dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
 
         res = np.array([dev.expval(O1), dev.expval(O2)])
@@ -154,17 +147,15 @@ class TestQVMBasic(BaseTest):
         phi = 0.123
 
         dev = plf.QVMDevice(device="2q-qvm", shots=shots)
-        O1 = qml.expval(qml.Hadamard(wires=[0]))
-        O2 = qml.expval(qml.Hadamard(wires=[1]))
 
-        circuit_graph = CircuitGraph(
-            [qml.RY(theta, wires=[0]), qml.RY(phi, wires=[1]), qml.CNOT(wires=[0, 1])] + [O1, O2],
-            {},
-            dev.wires,
-        )
+        with qml.tape.QuantumTape() as tape:
+            qml.RY(theta, wires=[0])
+            qml.RY(phi, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            O1 = qml.expval(qml.Hadamard(wires=[0]))
+            O2 = qml.expval(qml.Hadamard(wires=[1]))
 
-        dev.apply(circuit_graph.operations, rotations=circuit_graph.diagonalizing_gates)
-
+        dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
 
         res = np.array([dev.expval(O1), dev.expval(O2)])
@@ -186,17 +177,15 @@ class TestQVMBasic(BaseTest):
         phi = 0.123
 
         dev = plf.QVMDevice(device="2q-qvm", shots=shots)
-        O1 = qml.expval(qml.Hermitian(H, wires=[0]))
-        O2 = qml.expval(qml.Hermitian(H, wires=[1]))
 
-        circuit_graph = CircuitGraph(
-            [qml.RY(theta, wires=[0]), qml.RY(phi, wires=[1]), qml.CNOT(wires=[0, 1])] + [O1, O2],
-            {},
-            dev.wires,
-        )
+        with qml.tape.QuantumTape() as tape:
+            qml.RY(theta, wires=[0])
+            qml.RY(phi, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            O1 = qml.expval(qml.Hermitian(H, wires=[0]))
+            O2 = qml.expval(qml.Hermitian(H, wires=[1]))
 
-        dev.apply(circuit_graph.operations, rotations=circuit_graph.diagonalizing_gates)
-
+        dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
 
         res = np.array([dev.expval(O1), dev.expval(O2)])
@@ -227,14 +216,14 @@ class TestQVMBasic(BaseTest):
         )
 
         dev = plf.QVMDevice(device="2q-qvm", shots=10 * shots)
-        O1 = qml.expval(qml.Hermitian(A, wires=[0, 1]))
 
-        circuit_graph = CircuitGraph(
-            [qml.RY(theta, wires=[0]), qml.RY(phi, wires=[1]), qml.CNOT(wires=[0, 1])] + [O1], {}, dev.wires
-        )
+        with qml.tape.QuantumTape() as tape:
+            qml.RY(theta, wires=[0])
+            qml.RY(phi, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            O1 = qml.expval(qml.Hermitian(A, wires=[0, 1]))
 
-        dev.apply(circuit_graph.operations, rotations=circuit_graph.diagonalizing_gates)
-
+        dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
 
         res = np.array([dev.expval(O1)])
@@ -257,13 +246,12 @@ class TestQVMBasic(BaseTest):
         phi = 0.543
         theta = 0.6543
 
-        O1 = qml.var(qml.PauliZ(wires=[0]))
+        with qml.tape.QuantumTape() as tape:
+            qml.RX(phi, wires=[0])
+            qml.RY(theta, wires=[0])
+            O1 = qml.var(qml.PauliZ(wires=[0]))
 
-        circuit_graph = CircuitGraph([qml.RX(phi, wires=[0]), qml.RY(theta, wires=[0])] + [O1], {}, dev.wires)
-
-        # test correct variance for <Z> of a rotated state
-        dev.apply(circuit_graph.operations, rotations=circuit_graph.diagonalizing_gates)
-
+        dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
 
         var = np.array([dev.var(O1)])
@@ -280,13 +268,13 @@ class TestQVMBasic(BaseTest):
 
         A = np.array([[4, -1 + 6j], [-1 - 6j, 2]])
 
-        O1 = qml.var(qml.Hermitian(A, wires=[0]))
-
-        circuit_graph = CircuitGraph([qml.RX(phi, wires=[0]), qml.RY(theta, wires=[0])] + [O1], {}, dev.wires)
+        with qml.tape.QuantumTape() as tape:
+            qml.RX(phi, wires=[0])
+            qml.RY(theta, wires=[0])
+            O1 = qml.var(qml.Hermitian(A, wires=[0]))
 
         # test correct variance for <A> of a rotated state
-        dev.apply(circuit_graph.operations, rotations=circuit_graph.diagonalizing_gates)
-
+        dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
 
         var = np.array([dev.var(O1)])
@@ -304,7 +292,7 @@ class TestQVMBasic(BaseTest):
     )  # pylint: disable=protected-access
     def test_apply(self, gate, apply_unitary, shots, qvm, compiler):
         """Test the application of gates"""
-        dev = plf.QVMDevice(device="3q-qvm", shots=shots)
+        dev = plf.QVMDevice(device="3q-qvm", shots=shots, parametric_compilation=False)
 
         try:
             # get the equivalent pennylane operation class
@@ -316,7 +304,6 @@ class TestQVMBasic(BaseTest):
         # the list of wires to apply the operation to
         w = list(range(op.num_wires))
 
-        obs = qml.expval(qml.PauliZ(0))
         if op.par_domain == "A":
             # the parameter is an array
             if gate == "QubitUnitary":
@@ -328,7 +315,9 @@ class TestQVMBasic(BaseTest):
                 state = np.array([0, 0, 0, 0, 0, 0, 0, 1])
                 w = list(range(dev.num_wires))
 
-            circuit_graph = CircuitGraph([op(p, wires=w)] + [obs], {}, dev.wires)
+            with qml.tape.QuantumTape() as tape:
+                op(p, wires=w)
+                obs = qml.expval(qml.PauliZ(0))
         else:
             p = [0.432_423, 2, 0.324][: op.num_params]
             fn = test_operation_map[gate]
@@ -342,14 +331,19 @@ class TestQVMBasic(BaseTest):
 
             # calculate the expected output
             state = apply_unitary(O, 3)
-            # Creating the circuit graph using a parametrized operation
+            # Creating the tape using a parametrized operation
             if p:
-                circuit_graph = CircuitGraph([op(*p, wires=w)] + [obs], {}, dev.wires)
-            # Creating the circuit graph using an operation that take no parameters
-            else:
-                circuit_graph = CircuitGraph([op(wires=w)] + [obs], {}, dev.wires)
+                with qml.tape.QuantumTape() as tape:
+                    op(*p, wires=w)
+                    obs = qml.expval(qml.PauliZ(0))
 
-        dev.apply(circuit_graph.operations, rotations=circuit_graph.diagonalizing_gates)
+            # Creating the tape using an operation that take no parameters
+            else:
+                with qml.tape.QuantumTape() as tape:
+                    op(wires=w)
+                    obs = qml.expval(qml.PauliZ(0))
+
+        dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
         dev._samples = dev.generate_samples()
 

--- a/tests/test_wavefunction.py
+++ b/tests/test_wavefunction.py
@@ -47,12 +47,12 @@ class TestWavefunctionBasic(BaseTest):
         with qml.tape.QuantumTape() as tape:
             qml.RX(phi, wires=[0])
             qml.RY(theta, wires=[0])
-            qml.var(qml.PauliZ(wires=[0]))
+            O = qml.var(qml.PauliZ(wires=[0]))
 
         # test correct variance for <Z> of a rotated state
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
-        var = dev.var(qml.PauliZ(0))
+        var = dev.var(O)
         expected = 0.25 * (3 - np.cos(2 * theta) - 2 * np.cos(theta) ** 2 * np.cos(2 * phi))
 
         self.assertAlmostEqual(var, expected, delta=tol)
@@ -70,12 +70,12 @@ class TestWavefunctionBasic(BaseTest):
         with qml.tape.QuantumTape() as tape:
             qml.RX(phi, wires=[0])
             qml.RY(theta, wires=[0])
-            qml.var(qml.Hermitian(H, wires=[0]))
+            O = qml.var(qml.Hermitian(H, wires=[0]))
 
         # test correct variance for <Z> of a rotated state
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
-        var = dev.var(qml.Hermitian(H, wires=[0]))
+        var = dev.var(O)
         expected = 0.5 * (
             2 * np.sin(2 * theta) * np.cos(phi) ** 2
             + 24 * np.sin(phi) * np.cos(phi) * (np.sin(theta) - np.cos(theta))

--- a/tests/test_wavefunction.py
+++ b/tests/test_wavefunction.py
@@ -44,15 +44,13 @@ class TestWavefunctionBasic(BaseTest):
         phi = 0.543
         theta = 0.6543
 
-        circuit_operations = [qml.RX(phi, wires=[0]), qml.RY(theta, wires=[0])]
-
-        O = qml.var(qml.PauliZ(wires=[0]))
-
-        observables = [O]
-        circuit_graph = qml.CircuitGraph(circuit_operations + observables, {}, dev.wires)
+        with qml.tape.QuantumTape() as tape:
+            qml.RX(phi, wires=[0])
+            qml.RY(theta, wires=[0])
+            qml.var(qml.PauliZ(wires=[0]))
 
         # test correct variance for <Z> of a rotated state
-        dev.apply(circuit_graph.operations, rotations=circuit_graph.diagonalizing_gates)
+        dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
         var = dev.var(qml.PauliZ(0))
         expected = 0.25 * (3 - np.cos(2 * theta) - 2 * np.cos(theta) ** 2 * np.cos(2 * phi))
@@ -69,14 +67,13 @@ class TestWavefunctionBasic(BaseTest):
         # test correct variance for <H> of a rotated state
         H = np.array([[4, -1 + 6j], [-1 - 6j, 2]])
 
-        circuit_operations = [qml.RX(phi, wires=[0]), qml.RY(theta, wires=[0])]
+        with qml.tape.QuantumTape() as tape:
+            qml.RX(phi, wires=[0])
+            qml.RY(theta, wires=[0])
+            qml.var(qml.Hermitian(H, wires=[0]))
 
-        O = qml.var(qml.Hermitian(H, wires=[0]))
-
-        observables = [O]
-        circuit_graph = qml.CircuitGraph(circuit_operations + observables, {}, dev.wires)
-
-        dev.apply(circuit_graph.operations, rotations=circuit_graph.diagonalizing_gates)
+        # test correct variance for <Z> of a rotated state
+        dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
         var = dev.var(qml.Hermitian(H, wires=[0]))
         expected = 0.5 * (
@@ -117,7 +114,9 @@ class TestWavefunctionBasic(BaseTest):
                 state = np.array([0, 0, 0, 0, 0, 0, 0, 1])
                 w = list(range(dev.num_wires))
 
-            circuit_graph = qml.CircuitGraph([op(p, wires=w)] + [obs], {}, dev.wires)
+            with qml.tape.QuantumTape() as tape:
+                op(p, wires=w)
+                obs
         else:
             p = [0.432_423, 2, 0.324][: op.num_params]
             fn = test_operation_map[gate]
@@ -131,14 +130,19 @@ class TestWavefunctionBasic(BaseTest):
 
             # calculate the expected output
             state = apply_unitary(O, 3)
-            # Creating the circuit graph using a parametrized operation
+            # Creating the tape using a parametrized operation
             if p:
-                circuit_graph = qml.CircuitGraph([op(*p, wires=w)] + [obs], {}, dev.wires)
-            # Creating the circuit graph using an operation that take no parameters
-            else:
-                circuit_graph = qml.CircuitGraph([op(wires=w)] + [obs], {}, dev.wires)
+                with qml.tape.QuantumTape() as tape:
+                    op(*p, wires=w)
+                    obs
 
-        dev.apply(circuit_graph.operations, rotations=circuit_graph.diagonalizing_gates)
+            # Creating the tape using an operation that take no parameters
+            else:
+                with qml.tape.QuantumTape() as tape:
+                    op(wires=w)
+                    obs
+
+        dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
         res = dev.expval(obs)
 
@@ -152,14 +156,17 @@ class TestWavefunctionBasic(BaseTest):
         dev = plf.WavefunctionDevice(wires=1, shots=10)
         theta = 1.5708
 
-        circuit_operations = [qml.RX(theta, wires=[0])]
+        circuit_operations = []
 
         O = qml.sample(qml.PauliZ(0))
 
         observables = [O]
-        circuit_graph = qml.CircuitGraph(circuit_operations + observables, {}, dev.wires)
 
-        dev.apply(circuit_graph.operations, rotations=circuit_graph.diagonalizing_gates)
+        with qml.tape.QuantumTape() as tape:
+            qml.RX(theta, wires=[0])
+            qml.sample(qml.PauliZ(0))
+
+        dev.apply(tape._ops, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
         s1 = dev.sample(O)
 
@@ -175,14 +182,12 @@ class TestWavefunctionBasic(BaseTest):
 
         A = np.array([[1, 2j], [-2j, 0]])
 
-        circuit_operations = [qml.RX(theta, wires=[0])]
+        with qml.tape.QuantumTape() as tape:
+            qml.RX(theta, wires=[0])
+            O = qml.sample(qml.Hermitian(A, wires=[0]))
 
-        O = qml.sample(qml.Hermitian(A, wires=[0]))
-
-        observables = [O]
-        circuit_graph = qml.CircuitGraph(circuit_operations + observables, {}, dev.wires)
-
-        dev.apply(circuit_graph.operations, rotations=circuit_graph.diagonalizing_gates)
+        # test correct variance for <Z> of a rotated state
+        dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
         dev._samples = dev.generate_samples()
 
@@ -220,18 +225,14 @@ class TestWavefunctionBasic(BaseTest):
             ]
         )
 
-        circuit_operations = [
+        with qml.tape.QuantumTape() as tape:
             qml.RX(theta, wires=[0]),
             qml.RY(2 * theta, wires=[1]),
             qml.CNOT(wires=[0, 1]),
-        ]
+            O = qml.sample(qml.Hermitian(A, wires=[0, 1]))
 
-        O = qml.sample(qml.Hermitian(A, wires=[0, 1]))
-
-        observables = [O]
-        circuit_graph = qml.CircuitGraph(circuit_operations + observables, {}, dev.wires)
-
-        dev.apply(circuit_graph.operations, rotations=circuit_graph.diagonalizing_gates)
+        # test correct variance for <Z> of a rotated state
+        dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
         dev._samples = dev.generate_samples()
 
@@ -264,7 +265,7 @@ class TestWavefunctionIntegration(BaseTest):
         """Test that the wavefunction device loads correctly"""
         dev = qml.device("forest.wavefunction", wires=2)
         self.assertEqual(dev.num_wires, 2)
-        self.assertEqual(dev.shots, 1000)
+        self.assertEqual(dev.shots, None)
         self.assertEqual(dev.short_name, "forest.wavefunction")
 
     def test_program_property(self, qvm, compiler):


### PR DESCRIPTION
- [X] Removes the use of the `analytic` keyword to `shots=None`,
- [X] Changes from checking for a `Variable` to a condition on `requires_grad`,
- [X] Adds the circuit hash computation feature required by parametric compilation (as per https://github.com/PennyLaneAI/pennylane/pull/1182).
- [x] Refactor device tests (failing on the `CircuitGraph` object which is passed to apply)

Note: disallowed `BasisState` to be used for parametric compilation, as internally we don't use any parametrized gates to achieve it's effect (but rather apply PauliX and Identity operations, see `basis_state` function in `device.py`).