### PR TITLE
Fixes for version 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,16 @@
-# Release 0.16.0-dev
-
-### New features
-
-### Improvements
+# Release 0.16.0
 
 ### Bug fixes
 
-### Breaking changes
-
-### Documentation
+* Fixed a bug caused by the ``expand_state`` method always assuming that
+  inactive wires are the least significant bits.
+  [(#73)](https://github.com/PennyLaneAI/pennylane-forest/pull/73)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Antal Száva.
 
 ---
 

--- a/pennylane_forest/_version.py
+++ b/pennylane_forest/_version.py
@@ -2,4 +2,4 @@
    Version number (convention major.minor.patch[-label])
 """
 
-__version__ = "0.16.0-dev"
+__version__ = "0.16.0"

--- a/pennylane_forest/wavefunction.py
+++ b/pennylane_forest/wavefunction.py
@@ -92,9 +92,17 @@ class WavefunctionDevice(ForestDevice):
 
     @staticmethod
     def bit2dec(x):
-        """Auxiliary function that converts a bitstring to a decimal integer."""
+        """Auxiliary method that converts a bitstring to a decimal integer
+        using the PennyLane convention of bit ordering.
+
+        Args:
+            x (Iterable): bit string
+
+        Returns:
+            int: decimal value of the bitstring
+        """
         y = 0
-        for i, j in enumerate(x):
+        for i, j in enumerate(x[::-1]):
             y += j << i
         return y
 
@@ -127,7 +135,7 @@ class WavefunctionDevice(ForestDevice):
 
             # calculate the decimal value of the bit string, that gives the
             # index of the amplitude in the state vector
-            decimal_val = self.bit2dec(string[::-1])
+            decimal_val = self.bit2dec(string)
             expanded_state[decimal_val] = amplitude
 
         self._state = expanded_state

--- a/pennylane_forest/wavefunction.py
+++ b/pennylane_forest/wavefunction.py
@@ -120,7 +120,7 @@ class WavefunctionDevice(ForestDevice):
         inactive_wires = [x for x in range(len(self.wires)) if x not in device_active_wires]
 
         # initialize the entire new expanded state to zeros
-        expanded_state = np.zeros([2 ** len(self.wires)], dtype=self.C_TYPE)
+        expanded_state = np.zeros([2 ** len(self.wires)], dtype=self.C_DTYPE)
 
         # gather the bit strings for the subsystem made up of the active qubits
         subsystem_bit_strings = self.states_to_binary(

--- a/pennylane_forest/wavefunction.py
+++ b/pennylane_forest/wavefunction.py
@@ -90,6 +90,13 @@ class WavefunctionDevice(ForestDevice):
         self._state = self._state.reshape([2] * len(self._active_wires)).T.flatten()
         self.expand_state()
 
+    @staticmethod
+    def bool2int(x):
+        y = 0
+        for i,j in enumerate(x):
+            y += j<<i
+        return y
+
     def expand_state(self):
         """The pyQuil wavefunction simulator initializes qubits dymnically as they are requested.
         This method expands the state to the full number of wires in the device."""
@@ -98,20 +105,33 @@ class WavefunctionDevice(ForestDevice):
             # all wires in the device have been initialised
             return
 
-        num_inactive_wires = len(self.wires) - len(self._active_wires)
+        # len(self.wires) - len(self._active_wires)
 
         # translate active wires to the device's labels
         device_active_wires = self.map_wires(self._active_wires)
 
-        # place the inactive subsystems in the vacuum state
-        other_subsystems = np.zeros([2 ** num_inactive_wires])
-        other_subsystems[0] = 1
+        inactive_wires = [x for x in range(len(self.wires)) if x not in device_active_wires]
+
+        # initialize the entire new expanded state to zeros
+        expanded_state = np.zeros([2 ** len(self.wires)], dtype=np.complex128)
+
+        subsystem_bit_strings = self.states_to_binary(np.arange(2 ** len(self._active_wires)), len(self._active_wires))
+
+        for string, amplitude in zip(subsystem_bit_strings, self._state):
+            for w in inactive_wires:
+
+                # expand the bitstring by inserting the inactive zero qubits
+                string = np.insert(string, w, 0)
+
+            decimal_val = self.bool2int(string[::-1])
+            expanded_state[decimal_val] = amplitude
 
         # expand the state of the device into a length-num_wire state vector
-        expanded_state = np.kron(self._state, other_subsystems).reshape([2] * self.num_wires)
-        expanded_state = np.moveaxis(
-            expanded_state, range(len(device_active_wires)), device_active_wires.labels
-        )
-        expanded_state = expanded_state.flatten()
+        # expanded_state = np.kron(self._state, other_subsystems).reshape([2] * self.num_wires)
+        # expanded_state = np.moveaxis(
+        #     expanded_state, range(len(device_active_wires)), device_active_wires.labels
+        # )
+        # expanded_state = expanded_state.flatten()
 
         self._state = expanded_state
+

--- a/tests/test_wavefunction.py
+++ b/tests/test_wavefunction.py
@@ -417,8 +417,9 @@ class TestExpandState(BaseTest):
 
 
     @pytest.mark.parametrize("bitstring, dec", [([1], 1), ([0,0,1], 1), ([0,1,0], 2), ([1,1,1], 7)])
-    def test_expand_state(self, bitstring, dec):
-        """Test that a multi-qubit state is correctly expanded for a N-qubit device"""
+    def test_bit2dec(self, bitstring, dec):
+        """Test that the bit2dec method produces the correct decimal values for
+        bitstrings"""
         assert plf.WavefunctionDevice.bit2dec(bitstring) == dec
 
     @pytest.mark.parametrize("num_wires", [3,4] )

--- a/tests/test_wavefunction.py
+++ b/tests/test_wavefunction.py
@@ -416,15 +416,18 @@ class TestExpandState(BaseTest):
         self.assertAllEqual(dev._state, np.array([0, 1, 1, 0, 0, 1, 1, 0]) / 2)
 
 
-    #@pytest.mark.parametrize("num_wires", )
-    def test_expanded_matches_default_qubit(self):
-        dev_default_qubit = qml.device('default.qubit', wires=3)
-        dev_wavefunction = qml.device('forest.wavefunction', wires=3)
+    @pytest.mark.parametrize("num_wires", [3,4] )
+    @pytest.mark.parametrize("wire_idx1, wire_idx2", [(0, 0), (1, 0), (1, 1)] )
+    def test_expanded_matches_default_qubit(self, wire_idx1, wire_idx2, num_wires):
+        dev_default_qubit = qml.device('default.qubit', wires=num_wires)
+        dev_wavefunction = qml.device('forest.wavefunction', wires=num_wires)
 
         def circuit():
-            qml.Hadamard(0)
-            qml.CNOT(wires=[0,1])
-            return qml.probs(wires=[0,1,2])
+            qml.RY(np.pi/2, wires=[wire_idx1 + 1])
+            qml.RY(np.pi, wires=[wire_idx2 + 0])
+            qml.CNOT(wires=[wire_idx1 + 1, wire_idx2 + 0])
+            qml.CNOT(wires=[wire_idx1 + 1, wire_idx2 + 0])
+            return qml.probs(wires=list(range(num_wires)))
 
         qnode1 = qml.QNode(circuit, dev_wavefunction)
         qnode2 = qml.QNode(circuit, dev_default_qubit)

--- a/tests/test_wavefunction.py
+++ b/tests/test_wavefunction.py
@@ -416,9 +416,16 @@ class TestExpandState(BaseTest):
         self.assertAllEqual(dev._state, np.array([0, 1, 1, 0, 0, 1, 1, 0]) / 2)
 
 
+    @pytest.mark.parametrize("bitstring, dec", [([1], 1), ([0,0,1], 1), ([0,1,0], 2), ([1,1,1], 7)])
+    def test_expand_state(self, bitstring, dec):
+        """Test that a multi-qubit state is correctly expanded for a N-qubit device"""
+        assert plf.WavefunctionDevice.bit2dec(bitstring) == dec
+
     @pytest.mark.parametrize("num_wires", [3,4] )
     @pytest.mark.parametrize("wire_idx1, wire_idx2", [(0, 0), (1, 0), (1, 1)] )
     def test_expanded_matches_default_qubit(self, wire_idx1, wire_idx2, num_wires):
+        """Test that the statevector is expanded correctly by checking the
+        output of a QNode with default.qubit."""
         dev_default_qubit = qml.device('default.qubit', wires=num_wires)
         dev_wavefunction = qml.device('forest.wavefunction', wires=num_wires)
 
@@ -427,7 +434,7 @@ class TestExpandState(BaseTest):
             qml.RY(np.pi, wires=[wire_idx2 + 0])
             qml.CNOT(wires=[wire_idx1 + 1, wire_idx2 + 0])
             qml.CNOT(wires=[wire_idx1 + 1, wire_idx2 + 0])
-            return qml.probs(wires=list(range(num_wires)))
+            return qml.probs(range(num_wires))
 
         qnode1 = qml.QNode(circuit, dev_wavefunction)
         qnode2 = qml.QNode(circuit, dev_default_qubit)


### PR DESCRIPTION
- Fixes the `expand_state` method for the Wavefunction simulator device. Previously it always took the Kronecker product of the subsystems made up of the active wires followed by the subsystems of the inactive wires: `|psi> ⊗ |0...0>`. This, however, is incorrect in cases such as having 3 qubits, such that the middle qubit is inactive: `|psiA> ⊗ |0> ⊗ |psiB>` is not equal to`|psiA>⊗ |psiB> ⊗ |0> `.
- Bumps the version number to prepare for the v0.16.0 release.