### PR TITLE
[WIP] Support PyQuil v3.0

### DIFF
--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -32,12 +32,12 @@ Code details
 import uuid
 
 import numpy as np
+import os
 
 from collections import OrderedDict
 
 from pyquil import Program
-from pyquil.api._base_connection import ForestConnection
-from pyquil.api._config import PyquilConfig
+from pyquil.api import QCSClientConfiguration
 
 from pyquil.quil import DefGate
 from pyquil.gates import X, Y, Z, H, PHASE, RX, RY, RZ, CZ, SWAP, CNOT, S, T, CSWAP, I
@@ -50,8 +50,6 @@ from pennylane.wires import Wires
 
 from ._version import __version__
 
-
-pyquil_config = PyquilConfig()
 
 
 def basis_state(par, *wires):
@@ -186,14 +184,14 @@ class ForestDevice(QubitDevice):
 
     @staticmethod
     def _get_connection(**kwargs):
-        forest_url = kwargs.get("forest_url", pyquil_config.forest_url)
-        qvm_url = kwargs.get("qvm_url", pyquil_config.qvm_url)
-        compiler_url = kwargs.get("compiler_url", pyquil_config.quilc_url)
+        qvm_url_from_env = os.getenv('QCS_SETTINGS_APPLICATIONS_PYQUIL_QVM_URL')
+        compiler_url_from_env = os.getenv('QCS_SETTINGS_APPLICATIONS_PYQUIL_QUILC_URL')
+        qvm_url = kwargs.get("qvm_url", qvm_url_from_env)
+        compiler_url = kwargs.get("compiler_url", compiler_url_from_env)
 
-        connection = ForestConnection(
+        connection = QCSClientConfiguration(
             sync_endpoint=qvm_url,
             compiler_endpoint=compiler_url,
-            forest_cloud_endpoint=forest_url,
         )
 
         return connection

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,7 @@ from scipy.linalg import expm, block_diag
 
 from pyquil import get_qc, Program
 from pyquil.gates import I as Id
-from pyquil.api import QVMConnection, QVMCompiler, local_qvm
-from pyquil.api._config import PyquilConfig
+from pyquil.api import QVM, QVMCompiler, local_forest_runtime
 from pyquil.api._errors import UnknownApiError
 from pyquil.api._qvm import QVMNotRunning
 
@@ -142,7 +141,7 @@ def apply_unitary():
 @pytest.fixture(scope="session")
 def qvm():
     try:
-        qvm = QVMConnection(random_seed=52)
+        qvm = QVM(random_seed=52)
         qvm.run(Program(Id(0)), [])
         return qvm
     except (RequestException, UnknownApiError, QVMNotRunning, TypeError) as e:
@@ -152,9 +151,8 @@ def qvm():
 @pytest.fixture(scope="session")
 def compiler():
     try:
-        config = PyquilConfig()
         device = get_qc("3q-qvm").device
-        compiler = QVMCompiler(endpoint=config.quilc_url, device=device)
+        compiler = QVMCompiler(device=device)
         compiler.quil_to_native_quil(Program(Id(0)))
         return compiler
     except (RequestException, UnknownApiError, QVMNotRunning, TypeError) as e:


### PR DESCRIPTION
**Context**

The latest changes coming with PyQuil v3.0 have resulted in important API deprecations. This results in errors due to unavailable files.

Important to note are the ones related to `ForestConnectionand PyquilConfig was deprecated in v3.0 (and the _base_connection.py file was removed).

From the release notes:
```
PyquilConfig has been replaced by api.QCSClientConfiguration. As a result, the only supported configuration-related environment variables are:

QCS_SETTINGS_APPLICATIONS_PYQUIL_QVM_URL (replaces QVM_URL)
QCS_SETTINGS_APPLICATIONS_PYQUIL_QUILC_URL (replaces QUILC_URL)
QCS_SETTINGS_FILE_PATH (overrides location for settings.toml)
QCS_SECRETS_FILE_PATH (overrides location for secrets.toml)
ForestConnection and ForestSession have been removed. Connection information is now managed via api.QCSClientConfiguration and api.EngagementManager.
```
**Changes**
The changes required will be porting to the new version of the API.

