### PR TITLE
Increment version number to v0.17.0 and update QVM tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,4 @@
-# Release 0.17.0-dev
-
-### New features since last release
-
-### Breaking changes
-
-### Improvements
-
-### Documentation
+# Release 0.17.0
 
 ### Bug fixes
 

--- a/pennylane_forest/_version.py
+++ b/pennylane_forest/_version.py
@@ -2,4 +2,4 @@
    Version number (convention major.minor.patch[-label])
 """
 
-__version__ = "0.17.0-dev"
+__version__ = "0.17.0"

--- a/tests/test_qvm.py
+++ b/tests/test_qvm.py
@@ -58,8 +58,8 @@ class TestQVMBasic(BaseTest):
             qml.RX(theta, wires=[0])
             qml.RX(phi, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.Identity(wires=[0])
-            O2 = qml.Identity(wires=[1])
+            O1 = qml.expval(qml.Identity(wires=[0]))
+            O2 = qml.expval(qml.Identity(wires=[1]))
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
@@ -81,8 +81,8 @@ class TestQVMBasic(BaseTest):
             qml.RX(theta, wires=[0])
             qml.RX(phi, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.PauliZ(wires=[0])
-            O2 = qml.PauliZ(wires=[1])
+            O1 = qml.expval(qml.PauliZ(wires=[0]))
+            O2 = qml.expval(qml.PauliZ(wires=[1]))
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
@@ -105,8 +105,8 @@ class TestQVMBasic(BaseTest):
             qml.RY(theta, wires=[0])
             qml.RY(phi, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.PauliX(wires=[0])
-            O2 = qml.PauliX(wires=[1])
+            O1 = qml.expval(qml.PauliX(wires=[0]))
+            O2 = qml.expval(qml.PauliX(wires=[1]))
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
@@ -128,8 +128,8 @@ class TestQVMBasic(BaseTest):
             qml.RX(theta, wires=[0])
             qml.RX(phi, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.PauliY(wires=[0])
-            O2 = qml.PauliY(wires=[1])
+            O1 = qml.expval(qml.PauliY(wires=[0]))
+            O2 = qml.expval(qml.PauliY(wires=[1]))
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
@@ -152,8 +152,8 @@ class TestQVMBasic(BaseTest):
             qml.RY(theta, wires=[0])
             qml.RY(phi, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.Hadamard(wires=[0])
-            O2 = qml.Hadamard(wires=[1])
+            O1 = qml.expval(qml.Hadamard(wires=[0]))
+            O2 = qml.expval(qml.Hadamard(wires=[1]))
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
@@ -182,8 +182,8 @@ class TestQVMBasic(BaseTest):
             qml.RY(theta, wires=[0])
             qml.RY(phi, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.Hermitian(H, wires=[0])
-            O2 = qml.Hermitian(H, wires=[1])
+            O1 = qml.expval(qml.Hermitian(H, wires=[0]))
+            O2 = qml.expval(qml.Hermitian(H, wires=[1]))
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
@@ -221,7 +221,7 @@ class TestQVMBasic(BaseTest):
             qml.RY(theta, wires=[0])
             qml.RY(phi, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.Hermitian(A, wires=[0, 1])
+            O1 = qml.expval(qml.Hermitian(A, wires=[0, 1]))
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
@@ -249,7 +249,7 @@ class TestQVMBasic(BaseTest):
         with qml.tape.QuantumTape() as tape:
             qml.RX(phi, wires=[0])
             qml.RY(theta, wires=[0])
-            O1 = qml.PauliZ(wires=[0])
+            O1 = qml.var(qml.PauliZ(wires=[0]))
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
@@ -271,7 +271,7 @@ class TestQVMBasic(BaseTest):
         with qml.tape.QuantumTape() as tape:
             qml.RX(phi, wires=[0])
             qml.RY(theta, wires=[0])
-            O1 = qml.Hermitian(A, wires=[0])
+            O1 = qml.var(qml.Hermitian(A, wires=[0]))
 
         # test correct variance for <A> of a rotated state
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
@@ -317,7 +317,7 @@ class TestQVMBasic(BaseTest):
 
             with qml.tape.QuantumTape() as tape:
                 op(p, wires=w)
-                obs = qml.PauliZ(0)
+                obs = qml.expval(qml.PauliZ(0))
         else:
             p = [0.432_423, 2, 0.324][: op.num_params]
             fn = test_operation_map[gate]
@@ -335,13 +335,13 @@ class TestQVMBasic(BaseTest):
             if p:
                 with qml.tape.QuantumTape() as tape:
                     op(*p, wires=w)
-                    obs = qml.PauliZ(0)
+                    obs = qml.expval(qml.PauliZ(0))
 
             # Creating the tape using an operation that take no parameters
             else:
                 with qml.tape.QuantumTape() as tape:
                     op(wires=w)
-                    obs = qml.PauliZ(0)
+                    obs = qml.expval(qml.PauliZ(0))
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
@@ -363,7 +363,7 @@ class TestQVMBasic(BaseTest):
 
         with qml.tape.QuantumTape() as tape:
             qml.RX(1.5708, wires=[0])
-            O1 = qml.PauliZ(wires=[0])
+            O1 = qml.expval(qml.PauliZ(wires=[0]))
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
@@ -387,7 +387,7 @@ class TestQVMBasic(BaseTest):
 
         with qml.tape.QuantumTape() as tape:
             qml.RX(theta, wires=[0])
-            O1 = qml.Hermitian(A, wires=[0])
+            O1 = qml.sample(qml.Hermitian(A, wires=[0]))
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
@@ -432,7 +432,7 @@ class TestQVMBasic(BaseTest):
             qml.RX(theta, wires=[0])
             qml.RY(2 * theta, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.Hermitian(A, wires=[0, 1])
+            O1 = qml.sample(qml.Hermitian(A, wires=[0, 1]))
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
@@ -516,8 +516,8 @@ class TestQVMBasic(BaseTest):
             qml.RX(theta, wires=[0])
             qml.RX(phi, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.Identity(wires=[0])
-            O2 = qml.Identity(wires=[1])
+            O1 = qml.expval(qml.Identity(wires=[0]))
+            O2 = qml.expval(qml.Identity(wires=[1]))
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
@@ -536,7 +536,7 @@ class TestQVMBasic(BaseTest):
         with qml.tape.QuantumTape() as tape:
             qml.RZ(theta, wires=[0])
             qml.CZ(wires=[0, 1])
-            O1 = qml.PauliZ(wires=[0])
+            O1 = qml.expval(qml.PauliZ(wires=[0]))
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
@@ -558,8 +558,8 @@ class TestParametricCompilation(BaseTest):
             qml.RX(theta, wires=[0])
             qml.RX(phi, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.Identity(wires=[0])
-            O2 = qml.Identity(wires=[1])
+            O1 = qml.expval(qml.Identity(wires=[0]))
+            O2 = qml.expval(qml.Identity(wires=[1]))
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
@@ -599,8 +599,8 @@ class TestParametricCompilation(BaseTest):
             qml.RX(theta, wires=[0])
             qml.RX(phi, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.Identity(wires=[0])
-            O2 = qml.Identity(wires=[1])
+            O1 = qml.expval(qml.Identity(wires=[0]))
+            O2 = qml.expval(qml.Identity(wires=[1]))
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 

--- a/tests/test_qvm.py
+++ b/tests/test_qvm.py
@@ -65,7 +65,7 @@ class TestQVMBasic(BaseTest):
 
         dev._samples = dev.generate_samples()
 
-        res = np.array([dev.expval(O1), dev.expval(O2)])
+        res = np.array([dev.expval(O1.obs), dev.expval(O2.obs)])
 
         # below are the analytic expectation values for this circuit (trace should always be 1)
         self.assertAllAlmostEqual(res, np.array([1, 1]), delta=3 / np.sqrt(shots))
@@ -87,7 +87,7 @@ class TestQVMBasic(BaseTest):
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
 
-        res = np.array([dev.expval(O1), dev.expval(O2)])
+        res = np.array([dev.expval(O1.obs), dev.expval(O2.obs)])
 
         # below are the analytic expectation values for this circuit
         self.assertAllAlmostEqual(
@@ -111,7 +111,7 @@ class TestQVMBasic(BaseTest):
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
 
-        res = np.array([dev.expval(O1), dev.expval(O2)])
+        res = np.array([dev.expval(O1.obs), dev.expval(O2.obs)])
         # below are the analytic expectation values for this circuit
         self.assertAllAlmostEqual(
             res, np.array([np.sin(theta) * np.sin(phi), np.sin(phi)]), delta=3 / np.sqrt(shots)
@@ -134,7 +134,7 @@ class TestQVMBasic(BaseTest):
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
 
-        res = np.array([dev.expval(O1), dev.expval(O2)])
+        res = np.array([dev.expval(O1.obs), dev.expval(O2.obs)])
 
         # below are the analytic expectation values for this circuit
         self.assertAllAlmostEqual(
@@ -158,7 +158,7 @@ class TestQVMBasic(BaseTest):
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
 
-        res = np.array([dev.expval(O1), dev.expval(O2)])
+        res = np.array([dev.expval(O1.obs), dev.expval(O2.obs)])
 
         # below are the analytic expectation values for this circuit
         expected = np.array(
@@ -188,7 +188,7 @@ class TestQVMBasic(BaseTest):
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
 
-        res = np.array([dev.expval(O1), dev.expval(O2)])
+        res = np.array([dev.expval(O1.obs), dev.expval(O2.obs)])
 
         # below are the analytic expectation values for this circuit with arbitrary
         # Hermitian observable H
@@ -226,7 +226,7 @@ class TestQVMBasic(BaseTest):
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
 
-        res = np.array([dev.expval(O1)])
+        res = np.array([dev.expval(O1.obs)])
         # below is the analytic expectation value for this circuit with arbitrary
         # Hermitian observable A
         expected = 0.5 * (
@@ -254,7 +254,7 @@ class TestQVMBasic(BaseTest):
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
 
-        var = np.array([dev.var(O1)])
+        var = np.array([dev.var(O1.obs)])
         expected = 0.25 * (3 - np.cos(2 * theta) - 2 * np.cos(theta) ** 2 * np.cos(2 * phi))
 
         self.assertAlmostEqual(var, expected, delta=3 / np.sqrt(shots))
@@ -277,7 +277,7 @@ class TestQVMBasic(BaseTest):
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
 
-        var = np.array([dev.var(O1)])
+        var = np.array([dev.var(O1.obs)])
         expected = 0.5 * (
             2 * np.sin(2 * theta) * np.cos(phi) ** 2
             + 24 * np.sin(phi) * np.cos(phi) * (np.sin(theta) - np.cos(theta))
@@ -347,7 +347,7 @@ class TestQVMBasic(BaseTest):
 
         dev._samples = dev.generate_samples()
 
-        res = dev.expval(obs)
+        res = dev.expval(obs.obs)
         expected = np.vdot(state, np.kron(np.kron(Z, I), I) @ state)
 
         # verify the device is now in the expected state
@@ -369,7 +369,7 @@ class TestQVMBasic(BaseTest):
 
         dev._samples = dev.generate_samples()
 
-        s1 = dev.sample(O1)
+        s1 = dev.sample(O1.obs)
 
         # s1 should only contain 1 and -1
         self.assertAllAlmostEqual(s1 ** 2, 1, delta=tol)
@@ -393,7 +393,7 @@ class TestQVMBasic(BaseTest):
 
         dev._samples = dev.generate_samples()
 
-        s1 = dev.sample(O1)
+        s1 = dev.sample(O1.obs)
 
         # s1 should only contain the eigenvalues of
         # the hermitian matrix
@@ -438,7 +438,7 @@ class TestQVMBasic(BaseTest):
 
         dev._samples = dev.generate_samples()
 
-        s1 = dev.sample(O1)
+        s1 = dev.sample(O1.obs)
 
         # s1 should only contain the eigenvalues of
         # the hermitian matrix

--- a/tests/test_qvm.py
+++ b/tests/test_qvm.py
@@ -58,8 +58,8 @@ class TestQVMBasic(BaseTest):
             qml.RX(theta, wires=[0])
             qml.RX(phi, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.expval(qml.Identity(wires=[0]))
-            O2 = qml.expval(qml.Identity(wires=[1]))
+            O1 = qml.Identity(wires=[0])
+            O2 = qml.Identity(wires=[1])
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
@@ -81,8 +81,8 @@ class TestQVMBasic(BaseTest):
             qml.RX(theta, wires=[0])
             qml.RX(phi, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.expval(qml.PauliZ(wires=[0]))
-            O2 = qml.expval(qml.PauliZ(wires=[1]))
+            O1 = qml.PauliZ(wires=[0])
+            O2 = qml.PauliZ(wires=[1])
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
@@ -105,8 +105,8 @@ class TestQVMBasic(BaseTest):
             qml.RY(theta, wires=[0])
             qml.RY(phi, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.expval(qml.PauliX(wires=[0]))
-            O2 = qml.expval(qml.PauliX(wires=[1]))
+            O1 = qml.PauliX(wires=[0])
+            O2 = qml.PauliX(wires=[1])
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
@@ -128,8 +128,8 @@ class TestQVMBasic(BaseTest):
             qml.RX(theta, wires=[0])
             qml.RX(phi, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.expval(qml.PauliY(wires=[0]))
-            O2 = qml.expval(qml.PauliY(wires=[1]))
+            O1 = qml.PauliY(wires=[0])
+            O2 = qml.PauliY(wires=[1])
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
@@ -152,8 +152,8 @@ class TestQVMBasic(BaseTest):
             qml.RY(theta, wires=[0])
             qml.RY(phi, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.expval(qml.Hadamard(wires=[0]))
-            O2 = qml.expval(qml.Hadamard(wires=[1]))
+            O1 = qml.Hadamard(wires=[0])
+            O2 = qml.Hadamard(wires=[1])
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
@@ -182,8 +182,8 @@ class TestQVMBasic(BaseTest):
             qml.RY(theta, wires=[0])
             qml.RY(phi, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.expval(qml.Hermitian(H, wires=[0]))
-            O2 = qml.expval(qml.Hermitian(H, wires=[1]))
+            O1 = qml.Hermitian(H, wires=[0])
+            O2 = qml.Hermitian(H, wires=[1])
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
@@ -221,7 +221,7 @@ class TestQVMBasic(BaseTest):
             qml.RY(theta, wires=[0])
             qml.RY(phi, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.expval(qml.Hermitian(A, wires=[0, 1]))
+            O1 = qml.Hermitian(A, wires=[0, 1])
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
@@ -249,7 +249,7 @@ class TestQVMBasic(BaseTest):
         with qml.tape.QuantumTape() as tape:
             qml.RX(phi, wires=[0])
             qml.RY(theta, wires=[0])
-            O1 = qml.var(qml.PauliZ(wires=[0]))
+            O1 = qml.PauliZ(wires=[0])
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
@@ -271,7 +271,7 @@ class TestQVMBasic(BaseTest):
         with qml.tape.QuantumTape() as tape:
             qml.RX(phi, wires=[0])
             qml.RY(theta, wires=[0])
-            O1 = qml.var(qml.Hermitian(A, wires=[0]))
+            O1 = qml.Hermitian(A, wires=[0])
 
         # test correct variance for <A> of a rotated state
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
@@ -317,7 +317,7 @@ class TestQVMBasic(BaseTest):
 
             with qml.tape.QuantumTape() as tape:
                 op(p, wires=w)
-                obs = qml.expval(qml.PauliZ(0))
+                obs = qml.PauliZ(0)
         else:
             p = [0.432_423, 2, 0.324][: op.num_params]
             fn = test_operation_map[gate]
@@ -335,13 +335,13 @@ class TestQVMBasic(BaseTest):
             if p:
                 with qml.tape.QuantumTape() as tape:
                     op(*p, wires=w)
-                    obs = qml.expval(qml.PauliZ(0))
+                    obs = qml.PauliZ(0)
 
             # Creating the tape using an operation that take no parameters
             else:
                 with qml.tape.QuantumTape() as tape:
                     op(wires=w)
-                    obs = qml.expval(qml.PauliZ(0))
+                    obs = qml.PauliZ(0)
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
@@ -363,7 +363,7 @@ class TestQVMBasic(BaseTest):
 
         with qml.tape.QuantumTape() as tape:
             qml.RX(1.5708, wires=[0])
-            O1 = qml.expval(qml.PauliZ(wires=[0]))
+            O1 = qml.PauliZ(wires=[0])
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
@@ -387,7 +387,7 @@ class TestQVMBasic(BaseTest):
 
         with qml.tape.QuantumTape() as tape:
             qml.RX(theta, wires=[0])
-            O1 = qml.sample(qml.Hermitian(A, wires=[0]))
+            O1 = qml.Hermitian(A, wires=[0])
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
@@ -432,7 +432,7 @@ class TestQVMBasic(BaseTest):
             qml.RX(theta, wires=[0])
             qml.RY(2 * theta, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.sample(qml.Hermitian(A, wires=[0, 1]))
+            O1 = qml.Hermitian(A, wires=[0, 1])
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
@@ -516,8 +516,8 @@ class TestQVMBasic(BaseTest):
             qml.RX(theta, wires=[0])
             qml.RX(phi, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.expval(qml.Identity(wires=[0]))
-            O2 = qml.expval(qml.Identity(wires=[1]))
+            O1 = qml.Identity(wires=[0])
+            O2 = qml.Identity(wires=[1])
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
@@ -536,7 +536,7 @@ class TestQVMBasic(BaseTest):
         with qml.tape.QuantumTape() as tape:
             qml.RZ(theta, wires=[0])
             qml.CZ(wires=[0, 1])
-            O1 = qml.expval(qml.PauliZ(wires=[0]))
+            O1 = qml.PauliZ(wires=[0])
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
@@ -558,8 +558,8 @@ class TestParametricCompilation(BaseTest):
             qml.RX(theta, wires=[0])
             qml.RX(phi, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.expval(qml.Identity(wires=[0]))
-            O2 = qml.expval(qml.Identity(wires=[1]))
+            O1 = qml.Identity(wires=[0])
+            O2 = qml.Identity(wires=[1])
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 
@@ -599,8 +599,8 @@ class TestParametricCompilation(BaseTest):
             qml.RX(theta, wires=[0])
             qml.RX(phi, wires=[1])
             qml.CNOT(wires=[0, 1])
-            O1 = qml.expval(qml.Identity(wires=[0]))
-            O2 = qml.expval(qml.Identity(wires=[1]))
+            O1 = qml.Identity(wires=[0])
+            O2 = qml.Identity(wires=[1])
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 


### PR DESCRIPTION
* Bumps the version number to v0.17.0
* Changes QVM tests:

Sampling has been changed in
https://github.com/PennyLaneAI/pennylane/commit/2344a4acfb9698e26af79cbe67195c7bbe859922.

This affects how current QVM tests are handled. The tests create a `MeasurementProcess` and this affects the sampling mechanism. 