### PR TITLE
Remove qubit unitary check and adjust wavefunction simulator tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release 0.17.0
 
+### Improvements
+
+* Removed a validation check for ``QubitUnitary`` that is now in PennyLane
+  core.
+  [(#74)](https://github.com/PennyLaneAI/pennylane-forest/pull/74)
+
 ### Bug fixes
 
 * Pins the PyQuil version to use as `pyquil>=2.16,<2.28.3` due to API
@@ -10,7 +16,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Romain Moyard, Antal Száva.
+Theodor Isacsson, Romain Moyard, Antal Száva.
 
 ---
 

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -81,15 +81,6 @@ def qubit_unitary(par, *wires):
     Returns:
         list: list of PauliX matrix operators acting on each wire
     """
-    if par.shape[0] != par.shape[1]:
-        raise ValueError("Qubit unitary must be a square matrix.")
-
-    if not np.allclose(par @ par.conj().T, np.identity(par.shape[0])):
-        raise ValueError("Qubit unitary matrix must be unitary.")
-
-    if par.shape != tuple([2 ** len(wires)] * 2):
-        raise ValueError("Qubit unitary matrix must be 2^Nx2^N, where N is the number of wires.")
-
     # Get the Quil definition for the new gate
     gate_definition = DefGate("U_{}".format(str(uuid.uuid4())[:8]), par)
     # Get the gate constructor

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyquil>=2.16,<2.28.3
-pennylane>=0.15
+pennylane>=0.17
 networkx
 flaky

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyquil>=2.16,<2.28.3
-pennylane>=0.17
+git+https://github.com/PennyLaneAI/pennylane.git@v0.17.0-rc0
 networkx
 flaky

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("pennylane_forest/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
 
 
-requirements = ["pyquil>=2.16,<2.28.3", "pennylane>=0.15"]
+requirements = ["pyquil>=2.16,<2.28.3", "pennylane>=0.17"]
 
 info = {
     "name": "PennyLane-Forest",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("pennylane_forest/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
 
 
-requirements = ["pyquil>=2.16,<2.28.3", "pennylane>=0.17"]
+requirements = ["pyquil>=2.16,<2.28.3", "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@v0.17.0-rc0"]
 
 info = {
     "name": "PennyLane-Forest",

--- a/tests/test_numpy_wavefunction.py
+++ b/tests/test_numpy_wavefunction.py
@@ -149,7 +149,7 @@ class TestWavefunctionBasic(BaseTest):
 
         dev.apply(tape._ops, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
-        s1 = dev.sample(O)
+        s1 = dev.sample(O.obs)
 
         # s1 should only contain 1 and -1
         self.assertAllAlmostEqual(s1 ** 2, 1, delta=tol)
@@ -176,7 +176,7 @@ class TestWavefunctionBasic(BaseTest):
 
         dev._samples = dev.generate_samples()
 
-        s1 = dev.sample(O)
+        s1 = dev.sample(O.obs)
 
         # s1 should only contain the eigenvalues of
         # the hermitian matrix
@@ -221,7 +221,7 @@ class TestWavefunctionBasic(BaseTest):
 
         dev._samples = dev.generate_samples()
 
-        s1 = dev.sample(O)
+        s1 = dev.sample(O.obs)
 
         # s1 should only contain the eigenvalues of
         # the hermitian matrix
@@ -334,16 +334,8 @@ class TestWavefunctionIntegration(BaseTest):
             return qml.expval(qml.PauliZ(0))
 
         circuit1 = qml.QNode(circuit, dev)
-        with pytest.raises(ValueError, match="must be a square matrix"):
+        with pytest.raises(ValueError, match="Input unitary must be of shape"):
             circuit1(np.array([[0, 1]]))
-
-        circuit1 = qml.QNode(circuit, dev)
-        with pytest.raises(ValueError, match="must be unitary"):
-            circuit1(np.array([[1, 1], [1, 1]]))
-
-        circuit1 = qml.QNode(circuit, dev)
-        with pytest.raises(ValueError, match=r"must be 2\^Nx2\^N"):
-            circuit1(U)
 
     def test_one_qubit_wavefunction_circuit(self, tol):
         """Test that the wavefunction plugin provides correct result for simple circuit"""
@@ -361,7 +353,6 @@ class TestWavefunctionIntegration(BaseTest):
             qml.Rot(x, y, z, wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        print(circuit(a, b, c))
         self.assertAlmostEqual(circuit(a, b, c), np.cos(a) * np.sin(b), delta=tol)
 
     def test_two_qubit_wavefunction_circuit(self, tol):

--- a/tests/test_wavefunction.py
+++ b/tests/test_wavefunction.py
@@ -152,7 +152,7 @@ class TestWavefunctionBasic(BaseTest):
 
         dev.apply(tape._ops, rotations=tape.diagonalizing_gates)
         dev._samples = dev.generate_samples()
-        s1 = dev.sample(O)
+        s1 = dev.sample(O.obs)
 
         # s1 should only contain 1 and -1
         self.assertAllAlmostEqual(s1 ** 2, 1, delta=tol)
@@ -175,7 +175,7 @@ class TestWavefunctionBasic(BaseTest):
 
         dev._samples = dev.generate_samples()
 
-        s1 = dev.sample(O)
+        s1 = dev.sample(O.obs)
 
         # s1 should only contain the eigenvalues of
         # the hermitian matrix
@@ -220,7 +220,7 @@ class TestWavefunctionBasic(BaseTest):
 
         dev._samples = dev.generate_samples()
 
-        s1 = dev.sample(O)
+        s1 = dev.sample(O.obs)
 
         # s1 should only contain the eigenvalues of
         # the hermitian matrix
@@ -318,16 +318,8 @@ class TestWavefunctionIntegration(BaseTest):
             return qml.expval(qml.PauliZ(0))
 
         circuit1 = qml.QNode(circuit, dev)
-        with pytest.raises(ValueError, match="must be a square matrix"):
+        with pytest.raises(ValueError, match="Input unitary must be of shape"):
             circuit1(np.array([[0, 1]]))
-
-        circuit1 = qml.QNode(circuit, dev)
-        with pytest.raises(ValueError, match="must be unitary"):
-            circuit1(np.array([[1, 1], [1, 1]]))
-
-        circuit1 = qml.QNode(circuit, dev)
-        with pytest.raises(ValueError, match=r"must be 2\^Nx2\^N"):
-            circuit1(U)
 
     def test_one_qubit_wavefunction_circuit(self, tol, qvm, compiler):
         """Test that the wavefunction plugin provides correct result for simple circuit"""


### PR DESCRIPTION
* Further to #80, adjusts the wavefunction simulator tests
* Removes the `QubitUnitary` validation checks
* Pins to the release candidate of PennyLane, as the `QubitUnitary` validation checks will be in the new, v0.17.0 release

Note: after this PR, another one will be changing the requirements such that PennyLane v0.17.0 needs to be pulled.