### PR TITLE
Update `requirements.txt` to point to `master` of PL instead of rc to help with CI checks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyquil>=2.16,<2.28.3
-git+https://github.com/PennyLaneAI/pennylane.git@v0.17.0-rc0
+git+https://github.com/PennyLaneAI/pennylane.git
 networkx
 flaky


### PR DESCRIPTION
**Context**

`pip` has a confusion about pulling the `master` branch of PennyLane and the release candidate branch. It cannot resolve the situation well when 2 separate packages depend on PennyLane with one depending on `master` and the other on the release candidate branch.

This causes issues with running the CI check in the QML repo and in the [plugin test matrix too](https://github.com/PennyLaneAI/plugin-test-matrix/runs/3317666745?check_suite_focus=true).

**Changes**

Reverts the `requirements.txt` file to pull `master` of PennyLane.

**Possible drawbacks**

If the CI checks either in the QML repo or in the plugin test matrix should be failing, they might be due to new changes that are in `master` of PennyLane, but not in the release candidate.