### PR TITLE
Update `requirements.txt` to have `pennylane>=0.17`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release 0.17.0
 
+### Breaking changes
+
+* Deprecated Python 3.6. (#140)
+  [(#85)](https://github.com/PennyLaneAI/pennylane-forest/pull/85)
+
 ### Improvements
 
 * Removed a validation check for ``QubitUnitary`` that is now in PennyLane

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Breaking changes
 
-* Deprecated Python 3.6. (#140)
+* Deprecated Python 3.6.
   [(#85)](https://github.com/PennyLaneAI/pennylane-forest/pull/85)
 
 ### Improvements

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -164,7 +164,7 @@ class ForestDevice(QubitDevice):
             to estimate expectation values of observables.
             For simulator devices, 0 means the exact EV is returned.
     """
-    pennylane_requires = ">=0.15"
+    pennylane_requires = ">=0.17"
     version = __version__
     author = "Rigetti Computing Inc."
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyquil>=2.16,<2.28.3
-git+https://github.com/PennyLaneAI/pennylane.git@master
+pennylane>=0.17
 networkx
 flaky

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("pennylane_forest/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
 
 
-requirements = ["pyquil>=2.16,<2.28.3", "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@master"]
+requirements = ["pyquil>=2.16,<2.28.3", "pennylane>=0.17"]
 
 info = {
     "name": "PennyLane-Forest",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Update `requirements.txt` to have `pennylane>=0.17` after the PennyLane release and before the plugin release. It's required as validations were removed from the device that are now in v0.17.0 PennyLane core.