### PR TITLE
QVM runs with latest PennyLane

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyquil>=2.16,<2.28.3
-git+https://github.com/PennyLaneAI/pennylane.git@expand_fn_update
+git+https://github.com/PennyLaneAI/pennylane.git@expand_fn_meth
 networkx
 flaky

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyquil>=2.16,<2.28.3
-git+https://github.com/PennyLaneAI/pennylane.git
+git+https://github.com/PennyLaneAI/pennylane.git@expand_fn_update
 networkx
 flaky

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyquil>=2.16,<2.28.3
-pennylane>=0.17
+git+https://github.com/PennyLaneAI/pennylane.git
 networkx
 flaky

--- a/tests/test_qpu.py
+++ b/tests/test_qpu.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 TEST_QPU_LATTICES = ["4q-qvm"]
 
 
-@pytest.mark.xfail
+@pytest.mark.skip(reason="accessing the QPU is not supported by PennyLane-Forest")
 class TestQPUIntegration(BaseTest):
     """Test the wavefunction simulator works correctly from the PennyLane frontend."""
 
@@ -163,7 +163,7 @@ class TestQPUIntegration(BaseTest):
         assert np.allclose(res, exp, atol=2e-2)
 
 
-@pytest.mark.xfail
+@pytest.mark.skip(reason="accessing the QPU is not supported by PennyLane-Forest")
 class TestQPUBasic(BaseTest):
     """Unit tests for the QPU (as a QVM)."""
 

--- a/tests/test_qpu.py
+++ b/tests/test_qpu.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 TEST_QPU_LATTICES = ["4q-qvm"]
 
 
-@pytest.mark.skip(reason="accessing the QPU is not supported by PennyLane-Forest")
+@pytest.mark.xfail
 class TestQPUIntegration(BaseTest):
     """Test the wavefunction simulator works correctly from the PennyLane frontend."""
 
@@ -163,7 +163,7 @@ class TestQPUIntegration(BaseTest):
         assert np.allclose(res, exp, atol=2e-2)
 
 
-@pytest.mark.skip(reason="accessing the QPU is not supported by PennyLane-Forest")
+@pytest.mark.xfail
 class TestQPUBasic(BaseTest):
     """Unit tests for the QPU (as a QVM)."""
 


### PR DESCRIPTION
The `master` branch version of PennyLane seems to cause issues with ZMQ which is a package used under the hood by the QVM. In specific, device creation hangs due to a [recent change in the `Device` base class](https://github.com/PennyLaneAI/pennylane/blob/master/pennylane/_device.py#L144).

This has been causing device tests for the Forest plugin to fail and test runs take several hours (~6 hours).

When the linked line in the `Device` base class is removed/organized into a separate method (as is the case on the [PennyLane `expand_fn_meth` branch](https://github.com/PennyLaneAI/pennylane/compare/expand_fn_meth)) the hanging doesn't seem to arise.

Runtime of PennyLane `master` vs. `expand_fn_meth`:

1. [6 hours with `master`](https://github.com/PennyLaneAI/pennylane-forest/runs/4074358126?check_suite_focus=true) (got deactivated by GitHub), see relevant two commits: 
* https://github.com/PennyLaneAI/pennylane-forest/pull/87/commits/f19af5511043533d16e0eafcf63a91e4e1e4544f
* https://github.com/PennyLaneAI/pennylane-forest/pull/87/commits/7118e68c481550d716885f7d9d71429028a7b233 
2. [~3-4 minutes with the `expand_fn_meth` branch](https://github.com/PennyLaneAI/pennylane-forest/runs/4085148986?check_suite_focus=true), see the relevant commit:
* pinning to the `expand_fn_meth` branch: https://github.com/PennyLaneAI/pennylane-forest/pull/87/commits/5b9571f2008b91d5687813973167ea329e756580

Locally, the following is the output when interrupting the hanging test runs:
![Screenshot from 2021-11-03 09-46-17](https://user-images.githubusercontent.com/24476053/140072197-c26eaf65-4b0d-4c38-820c-79ad4def0e47.png)


