### PR TITLE
Fix integration tests and adapt test for `par_domain`removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 0.18.0-dev
+# Release 0.20.0-dev
 
 ### New features since last release
 
@@ -10,9 +10,15 @@
 
 ### Bug fixes
 
+* Fix a bug where array parameters where not accepted when building circuits on
+  pyQuil side.
+  [(#90)](https://github.com/PennyLaneAI/pennylane-forest/pull/90)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Romain Moyard.
 
 ---
 

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -217,7 +217,7 @@ class ForestDevice(QubitDevice):
             device_wires = self.map_wires(operation.wires)
             par = operation.parameters
 
-            if isinstance(par, list) and len(list) > 0:
+            if isinstance(par, list) and len(par) > 0:
                 if isinstance(par[0], np.ndarray) and len(par[0]) == 1:
                     # Array not supported
                     par = [float(i) for i in par]

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -50,7 +50,6 @@ from pennylane.wires import Wires
 
 from ._version import __version__
 
-
 pyquil_config = PyquilConfig()
 
 
@@ -216,12 +215,15 @@ class ForestDevice(QubitDevice):
             # map the ops' wires to the wire labels used by the device
             device_wires = self.map_wires(operation.wires)
             par = operation.parameters
+            # Array not supportedd
+            par = [float(i) for i in par]
 
             if i > 0 and operation.name in ("QubitStateVector", "BasisState"):
                 raise DeviceError(
                     "Operation {} cannot be used after other Operations have already "
                     "been applied on a {} device.".format(operation.name, self.short_name)
                 )
+
             self.prog += self._operation_map[operation.name](*par, *device_wires.labels)
 
         self.prog += self.apply_rotations(rotations)
@@ -271,7 +273,7 @@ class ForestDevice(QubitDevice):
 
         if mat.shape != (2 ** num_wires, 2 ** num_wires):
             raise ValueError(
-                f"Please specify a {2**num_wires} x {2**num_wires} matrix for {num_wires} wires."
+                f"Please specify a {2 ** num_wires} x {2 ** num_wires} matrix for {num_wires} wires."
             )
 
         # first, we need to reshape both the matrix and vector

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -81,7 +81,8 @@ def qubit_unitary(par, *wires):
         list: list of PauliX matrix operators acting on each wire
     """
     # Get the Quil definition for the new gate
-    gate_definition = DefGate("U_{}".format(str(uuid.uuid4())[:8]), par)
+    u_str = str(uuid.uuid4())[:8]
+    gate_definition = DefGate(f"U_{u_str}", par)
     # Get the gate constructor
     gate_constructor = gate_definition.get_constructor()
     return [gate_definition, gate_constructor(*wires)]
@@ -215,13 +216,17 @@ class ForestDevice(QubitDevice):
             # map the ops' wires to the wire labels used by the device
             device_wires = self.map_wires(operation.wires)
             par = operation.parameters
-            # Array not supportedd
-            par = [float(i) for i in par]
+
+            if isinstance(par[0], array):
+                # Array not supported
+                par = [float(i) for i in par]
 
             if i > 0 and operation.name in ("QubitStateVector", "BasisState"):
+                name = operation.name
+                short_name = self.short_name
                 raise DeviceError(
-                    "Operation {} cannot be used after other Operations have already "
-                    "been applied on a {} device.".format(operation.name, self.short_name)
+                    f"Operation {name} cannot be used after other Operations have already "
+                    f"been applied on a {short_name} device."
                 )
 
             self.prog += self._operation_map[operation.name](*par, *device_wires.labels)

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -217,7 +217,7 @@ class ForestDevice(QubitDevice):
             device_wires = self.map_wires(operation.wires)
             par = operation.parameters
 
-            if isinstance(par, list) and len(par) > 0:
+            if isinstance(par, list) and par is not None:
                 if isinstance(par[0], np.ndarray) and len(par[0]) == 1:
                     # Array not supported
                     par = [float(i) for i in par]

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -217,9 +217,10 @@ class ForestDevice(QubitDevice):
             device_wires = self.map_wires(operation.wires)
             par = operation.parameters
 
-            if isinstance(par[0], np.ndarray):
-                # Array not supported
-                par = [float(i) for i in par]
+            if isinstance(par, list):
+                if isinstance(par[0], np.ndarray) and len(par[0])==1:
+                    # Array not supported
+                    par = [float(i) for i in par]
 
             if i > 0 and operation.name in ("QubitStateVector", "BasisState"):
                 name = operation.name

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -216,8 +216,8 @@ class ForestDevice(QubitDevice):
             # map the ops' wires to the wire labels used by the device
             device_wires = self.map_wires(operation.wires)
             par = operation.parameters
-
-            if isinstance(par, list) and par is not None:
+            print(par)
+            if isinstance(par, list) and par:
                 if isinstance(par[0], np.ndarray) and len(par[0]) == 1:
                     # Array not supported
                     par = [float(i) for i in par]

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -217,8 +217,8 @@ class ForestDevice(QubitDevice):
             device_wires = self.map_wires(operation.wires)
             par = operation.parameters
 
-            if isinstance(par, list):
-                if isinstance(par[0], np.ndarray) and len(par[0])==1:
+            if isinstance(par, list) and len(list) > 0:
+                if isinstance(par[0], np.ndarray) and len(par[0]) == 1:
                     # Array not supported
                     par = [float(i) for i in par]
 

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -216,9 +216,9 @@ class ForestDevice(QubitDevice):
             # map the ops' wires to the wire labels used by the device
             device_wires = self.map_wires(operation.wires)
             par = operation.parameters
-            print(par)
+
             if isinstance(par, list) and par:
-                if isinstance(par[0], np.ndarray) and len(par[0]) == 1:
+                if isinstance(par[0], np.ndarray) and par[0].shape == ():
                     # Array not supported
                     par = [float(i) for i in par]
 

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -217,7 +217,7 @@ class ForestDevice(QubitDevice):
             device_wires = self.map_wires(operation.wires)
             par = operation.parameters
 
-            if isinstance(par[0], array):
+            if isinstance(par[0], np.ndarray):
                 # Array not supported
                 par = [float(i) for i in par]
 

--- a/pennylane_forest/wavefunction.py
+++ b/pennylane_forest/wavefunction.py
@@ -82,7 +82,7 @@ class WavefunctionDevice(ForestDevice):
 
     def apply(self, operations, **kwargs):
         super().apply(operations, **kwargs)
-
+        print("prog", self.prog)
         self._state = self.qc.wavefunction(self.prog).amplitudes
 
         # pyQuil uses the convention that the first qubit is the least significant

--- a/pennylane_forest/wavefunction.py
+++ b/pennylane_forest/wavefunction.py
@@ -82,7 +82,6 @@ class WavefunctionDevice(ForestDevice):
 
     def apply(self, operations, **kwargs):
         super().apply(operations, **kwargs)
-        print("prog", self.prog)
         self._state = self.qc.wavefunction(self.prog).amplitudes
 
         # pyQuil uses the convention that the first qubit is the least significant

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyquil>=2.16,<2.28.3
-pennylane>=0.17
+git+git://github.com/PennyLaneAI/pennylane
 networkx
 flaky

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("pennylane_forest/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
 
 
-requirements = ["pyquil>=2.16,<2.28.3", "pennylane>=0.17"]
+requirements = ["pyquil>=2.16,<2.28.3", "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@master"]
 
 info = {
     "name": "PennyLane-Forest",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("pennylane_forest/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
 
 
-requirements = ["pyquil>=2.16,<2.28.3", "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@master"]
+requirements = ["pyquil>=2.16,<2.28.3", "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git"]
 
 info = {
     "name": "PennyLane-Forest",

--- a/tests/test_qvm.py
+++ b/tests/test_qvm.py
@@ -942,6 +942,9 @@ class TestQVMIntegration(BaseTest):
 
         results2 = qnodes2(params)
 
+        print("qvm", results)
+        print("default", results2)
+
         assert np.allclose(results, results2, atol=2e-02, rtol=0)
         assert dev.circuit_hash in dev._compiled_program_dict
         assert len(dev._compiled_program_dict.items()) == 1

--- a/tests/test_qvm.py
+++ b/tests/test_qvm.py
@@ -896,7 +896,7 @@ class TestQVMIntegration(BaseTest):
         obs_list = obs * number_of_qnodes
 
         qnodes = qml.map(qml.templates.StronglyEntanglingLayers, obs_list, dev)
-        params = qml.init.strong_ent_layers_normal(n_layers=4, n_wires=dev.num_wires)
+        params = qml.StronglyEntanglingLayers.shape(n_layers=4, n_wires=dev.num_wires)
 
         # For the first evaluation, use the real compile method
         qnodes[0](params)
@@ -928,7 +928,7 @@ class TestQVMIntegration(BaseTest):
         obs_list = obs * number_of_qnodes
 
         dev = qml.device("forest.qvm", device=device, timeout=100)
-        params = qml.init.strong_ent_layers_normal(n_layers=4, n_wires=dev.num_wires)
+        params = qml.StronglyEntanglingLayers.shape(n_layers=4, n_wires=dev.num_wires)
 
         qnodes = qml.map(qml.templates.StronglyEntanglingLayers, obs_list, dev)
 

--- a/tests/test_qvm.py
+++ b/tests/test_qvm.py
@@ -288,60 +288,54 @@ class TestQVMBasic(BaseTest):
         self.assertAlmostEqual(var, expected, delta=0.3)
 
     @pytest.mark.parametrize(
-        "gate", plf.QVMDevice._operation_map
-    )  # pylint: disable=protected-access
-    def test_apply(self, gate, apply_unitary, shots, qvm, compiler):
-        """Test the application of gates"""
+        "op",
+        [
+            qml.QubitUnitary(np.array(U), wires=0),
+            qml.BasisState(np.array([1, 1, 1]), wires=list(range(3))),
+            qml.PauliX(wires=0),
+            qml.PauliY(wires=0),
+            qml.PauliZ(wires=0),
+            qml.S(wires=0),
+            qml.T(wires=0),
+            qml.RX(0.432, wires=0),
+            qml.RY(0.432, wires=0),
+            qml.RZ(0.432, wires=0),
+            qml.Hadamard(wires=0),
+            qml.Rot(0.432, 2, 0.324, wires=0),
+            qml.Toffoli(wires=[0, 1, 2]),
+            qml.SWAP(wires=[0, 1]),
+            qml.CSWAP(wires=[0, 1, 2]),
+            qml.CZ(wires=[0, 1]),
+            qml.CNOT(wires=[0, 1]),
+            qml.PhaseShift(0.432, wires=0),
+            qml.CSWAP(wires=[0, 1, 2]),
+            plf.CPHASE(0.432, 2, wires=[0, 1]),
+            plf.ISWAP(wires=[0, 1]),
+            plf.PSWAP(0.432, wires=[0, 1]),
+        ],
+    )
+    def test_apply(self, op, apply_unitary, shots, qvm, compiler):
+        """Test the application of gates to a state"""
         dev = plf.QVMDevice(device="3q-qvm", shots=shots, parametric_compilation=False)
 
-        try:
-            # get the equivalent pennylane operation class
-            op = getattr(qml.ops, gate)
-        except AttributeError:
-            # get the equivalent pennylane-forest operation class
-            op = getattr(plf, gate)
+        obs = qml.expval(qml.PauliZ(0))
 
-        # the list of wires to apply the operation to
-        w = list(range(op.num_wires))
-
-        if op.par_domain == "A":
-            # the parameter is an array
-            if gate == "QubitUnitary":
-                p = np.array(U)
-                w = [0]
-                state = apply_unitary(U, 3)
-            elif gate == "BasisState":
-                p = np.array([1, 1, 1])
-                state = np.array([0, 0, 0, 0, 0, 0, 0, 1])
-                w = list(range(dev.num_wires))
-
-            with qml.tape.QuantumTape() as tape:
-                op(p, wires=w)
-                obs = qml.expval(qml.PauliZ(0))
+        if op.name == "QubitUnitary":
+            state = apply_unitary(U, 3)
+        elif op.name == "BasisState":
+            state = np.array([0, 0, 0, 0, 0, 0, 0, 1])
+        elif op.name == "CPHASE":
+            state = apply_unitary(test_operation_map["CPHASE"](0.432, 2), 3)
+        elif op.name == "ISWAP":
+            state = apply_unitary(test_operation_map["ISWAP"], 3)
+        elif op.name == "PSWAP":
+            state = apply_unitary(test_operation_map["PSWAP"](0.432), 3)
         else:
-            p = [0.432_423, 2, 0.324][: op.num_params]
-            fn = test_operation_map[gate]
-            if callable(fn):
-                # if the default.qubit is an operation accepting parameters,
-                # initialise it using the parameters generated above.
-                O = fn(*p)
-            else:
-                # otherwise, the operation is simply an array.
-                O = fn
+            state = apply_unitary(op.matrix, 3)
 
-            # calculate the expected output
-            state = apply_unitary(O, 3)
-            # Creating the tape using a parametrized operation
-            if p:
-                with qml.tape.QuantumTape() as tape:
-                    op(*p, wires=w)
-                    obs = qml.expval(qml.PauliZ(0))
-
-            # Creating the tape using an operation that take no parameters
-            else:
-                with qml.tape.QuantumTape() as tape:
-                    op(wires=w)
-                    obs = qml.expval(qml.PauliZ(0))
+        with qml.tape.QuantumTape() as tape:
+            qml.apply(op)
+            obs
 
         dev.apply(tape.operations, rotations=tape.diagonalizing_gates)
 

--- a/tests/test_qvm.py
+++ b/tests/test_qvm.py
@@ -942,10 +942,7 @@ class TestQVMIntegration(BaseTest):
 
         results2 = qnodes2(params)
 
-        print("qvm", results)
-        print("default", results2)
-
-        assert np.allclose(results, results2, atol=2e-02, rtol=0)
+        assert np.allclose(results, results2, atol=6e-02, rtol=0)
         assert dev.circuit_hash in dev._compiled_program_dict
         assert len(dev._compiled_program_dict.items()) == 1
 

--- a/tests/test_qvm.py
+++ b/tests/test_qvm.py
@@ -896,7 +896,8 @@ class TestQVMIntegration(BaseTest):
         obs_list = obs * number_of_qnodes
 
         qnodes = qml.map(qml.templates.StronglyEntanglingLayers, obs_list, dev)
-        params = qml.StronglyEntanglingLayers.shape(n_layers=4, n_wires=dev.num_wires)
+        shape = qml.StronglyEntanglingLayers.shape(n_layers=4, n_wires=dev.num_wires)
+        params = np.random.random(size=shape)
 
         # For the first evaluation, use the real compile method
         qnodes[0](params)
@@ -928,7 +929,9 @@ class TestQVMIntegration(BaseTest):
         obs_list = obs * number_of_qnodes
 
         dev = qml.device("forest.qvm", device=device, timeout=100)
-        params = qml.StronglyEntanglingLayers.shape(n_layers=4, n_wires=dev.num_wires)
+
+        shape = qml.StronglyEntanglingLayers.shape(n_layers=4, n_wires=dev.num_wires)
+        params = np.random.random(size=shape)
 
         qnodes = qml.map(qml.templates.StronglyEntanglingLayers, obs_list, dev)
 


### PR DESCRIPTION
Due to recent PennyLane changes, some parameters are given as array and it is not supported by Pyquil. We apply a small fix to transform the parameters to floats.

Multiple tests were also changed due to the removal of `par_domain` in PennyLane.