### PR TITLE
Reset PL requirement & Python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, '3.10']
 
     steps:
       - name: Cancel Previous Runs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
   pyQuil side.
   [(#90)](https://github.com/PennyLaneAI/pennylane-forest/pull/90)
 
+### Improvements
+
+* Added support for Python 3.10.
+  [(#96)](https://github.com/PennyLaneAI/pennylane-forest/pull/96)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyquil>=2.16,<2.28.3
-git+git://github.com/PennyLaneAI/pennylane
+pennylane>=0.17
 networkx
 flaky

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("pennylane_forest/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
 
 
-requirements = ["pyquil>=2.16,<2.28.3", "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git"]
+requirements = ["pyquil>=2.16,<2.28.3", "pennylane>=0.17"]
 
 info = {
     "name": "PennyLane-Forest",

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Physics",
 ]


### PR DESCRIPTION
* Resets the requirement of PennyLane (only the tests were adjusted to the new version of PennyLane core, no feature is being used from it);
* Adds support for Python 3.10.