### PR TITLE
QPUDevice: Skip generate_samples to avoid executing a circuit twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Improvements
 
+* Improves the computation of the expectation value when using `QPUDevice` by
+  skipping the `Device.generate_samples` method.
+  [#108](https://github.com/PennyLaneAI/pennylane-forest/pull/108)
+
 ### Documentation
 
 ### Bug fixes

--- a/pennylane_forest/qpu.py
+++ b/pennylane_forest/qpu.py
@@ -201,6 +201,4 @@ class QPUDevice(QuantumComputerDevice):
         return super().execute(circuit, **kwargs)
 
     def generate_samples(self):
-        if self._skip_generate_samples:
-            return
-        return super().generate_samples()
+        return None if self._skip_generate_samples else super().generate_samples()

--- a/pennylane_forest/qpu.py
+++ b/pennylane_forest/qpu.py
@@ -201,5 +201,6 @@ class QPUDevice(QuantumComputerDevice):
         return super().execute(circuit, **kwargs)
 
     def generate_samples(self):
-        if not self._skip_generate_samples:
-            return super().generate_samples()
+        if self._skip_generate_samples:
+            return
+        return super().generate_samples()

--- a/tests/test_pyqvm.py
+++ b/tests/test_pyqvm.py
@@ -277,7 +277,6 @@ class TestPyQVMBasic(BaseTest):
         # verify the device is now in the expected state
         # Note we have increased the tolerance here, since we are only
         # performing 1024 shots.
-
         self.assertAllAlmostEqual(res, expected, delta=3 / np.sqrt(shots))
 
 

--- a/tests/test_pyqvm.py
+++ b/tests/test_pyqvm.py
@@ -277,6 +277,7 @@ class TestPyQVMBasic(BaseTest):
         # verify the device is now in the expected state
         # Note we have increased the tolerance here, since we are only
         # performing 1024 shots.
+
         self.assertAllAlmostEqual(res, expected, delta=3 / np.sqrt(shots))
 
 


### PR DESCRIPTION
**Context**:
When running the following code, the circuit is executed twice: once by the `Device.generate_samples` method and another one by the `QPUDevice.expval` method, but only the results from the last method are used.
```python
dev = qml.device("forest.qpu", device="4q-qvm", shots=10000, load_qc=False, parametric_compilation=False)

@qml.qnode(dev)
def circuit():
    return qml.counts(qml.PauliZ(0))

print(circuit())
```
**Issue**: https://github.com/PennyLaneAI/pennylane-forest/issues/45
**Description of the change**: Skip `Device.generate_samples` when executing a circuit with `expval` and `parametric_compilation=False`
**Possible drawbacks**: We are overriding the `Device.execute` method, which is not recommended.